### PR TITLE
Import functools.lru_cache agnostically, fixes #2

### DIFF
--- a/host/pygreat/comms.py
+++ b/host/pygreat/comms.py
@@ -18,7 +18,10 @@ import collections
 
 from . import errors
 
-from backports.functools_lru_cache import lru_cache as memoize_with_lru_cache
+try:
+    from functools import lru_cache as memoize_with_lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache as memoize_with_lru_cache
 
 
 class CommsError(IOError):

--- a/host/setup.py
+++ b/host/setup.py
@@ -32,7 +32,11 @@ setup(
     author='Katherine J. Temkin',
     author_email='ktemkin@greatscottgadgets.com',
     tests_require=[''],
-    install_requires=['pyusb', 'future', 'backports.functools_lru_cache'],
+    install_requires=[
+        'pyusb',
+        'future',
+        'backports.functools_lru_cache;python_version<"3.3"'
+    ],
     description='Python library for talking with libGreat devices',
     long_description=read('../README.md'),
     packages=find_packages(),


### PR DESCRIPTION
This fixes issue #2 by doing two things:

1. Import `lru_cache` in a python{2,3} agnostic way
2. Define `backports.functools_lru_cache` as an `install_requires` conditionally