### PR TITLE
Fixes a type bug returned by the regex match method in Python 3.7

### DIFF
--- a/host/pygreat/comms.py
+++ b/host/pygreat/comms.py
@@ -399,8 +399,10 @@ class CommsBackend(object):
             if match.groups(1) is None:
                 return 1
             else:
-                return int(match.groups(1))
-
+                val_ret = match.groups(1) # returned value
+                if type(val_ret).__name__ == 'tuple': # take the first element if it returns a tuple
+                    val_ret = val_ret[0]
+                return int(val_ret)
 
         # Sanity check: this string doesn't contain a string.
         if ('S' in format_string) or ('X' in format_string) or ('*' in format_string):


### PR DESCRIPTION
Hi,

I recently got an exception on Python 3.7 with the following error:
```
  File "/<path>/site-packages/pygreat/comms.py", line 403, in _get_bytes_consumed_by_format
    return int(match.groups(1))
TypeError: unexpected return RPC `read_setup`; innner message: int() argument must be a string, a bytes-like object or a number, not 'tuple'; format: <8X
```
So I've patched this line to check if the value returned by match.groups() is a tuple or not, and if so it takes the first element of the tuple.

Thanks in advance!

Cheers!