### PR TITLE
host: use array.tobytes() instead of tostring() (dropped in py3.9)

### DIFF
--- a/host/pygreat/comms_backends/usb.py
+++ b/host/pygreat/comms_backends/usb.py
@@ -240,7 +240,7 @@ class USBCommsBackend(CommsBackend):
         """
         raw = self._vendor_request(usb.ENDPOINT_IN, request, length_or_data=length,
             value=value, index=index, timeout=timeout)
-        return raw.tostring().encode(encoding, errors='ignore')
+        return raw.tobytes().encode(encoding, errors='ignore')
 
 
     def _vendor_request_out(self, request, value=0, index=0, data=None, timeout=1000):
@@ -371,10 +371,10 @@ class USBCommsBackend(CommsBackend):
 
                 # If we were passed an encoding, attempt to decode the response data.
                 if encoding and response:
-                    response = response.tostring().decode(encoding, errors='ignore')
+                    response = response.tobytes().decode(encoding, errors='ignore')
 
                 # Return the device's response.
-                return response.tostring()
+                return response.tobytes()
 
             except Exception as e:
 


### PR DESCRIPTION
This is a Python 2 incompatible change.