### PR TITLE
handle usb exclusive access on windows

### DIFF
--- a/host/pygreat/comms_backends/usb.py
+++ b/host/pygreat/comms_backends/usb.py
@@ -142,9 +142,12 @@ class USBCommsBackend(CommsBackend):
                 return
             except usb.core.USBError as e:
 
-                # If we have EBUSY (linux) or EACCES (macos), or None (windows), try again.
-                if e.errno in (errno.EBUSY, errno.EACCES, None):
+                # If we have EBUSY (linux) or EACCES (macos), try again.
+                if e.errno in (errno.EBUSY, errno.EACCES):
                     pass
+                # If we have None (windows), just return.
+                elif e.errno in (None, ):
+                    return
                 else:
                     raise
 


### PR DESCRIPTION
Instead of waiting for exclusive access when e.errno is None, just return.
This addresses issue #327.  Limited testing performed, but the device seems to work in i2c, info, and some facedancer testing.