### PR TITLE
Packaging: migrate from setup.py to pyproject.toml

### DIFF
--- a/host/pyproject.toml
+++ b/host/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pygreat"
 dynamic = ["version"]
 authors = [
-    {name = "Katherine J. Temkin", email = "ktemkin@greatscottgadgets.com"},
+    {name = "Great Scott Gadgets", email = "dev@greatscottgadgets.com"},
 ]
 license = { text = "BSD" }
 description = "Python library for talking with libGreat devices"
@@ -14,7 +14,7 @@ urls = { Source = "https://greatscottgadgets.com/greatfet" }
 readme = "README.md"
 classifiers = [
     "Programming Language :: Python",
-    "Development Status :: 1 - Planning",
+    "Development Status :: 5 - Production/Stable",
     "Natural Language :: English",
     "Environment :: Console",
     "Environment :: Plugins",

--- a/host/setup.py
+++ b/host/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
This PR contains:

1. Metadata updates for authors and development status
2. A shim for `setup.py` as CI still relies on a `python setup.py` flow