### PR TITLE
Add drive strength register to LPC43XX SCU GPIO pin configuration

### DIFF
--- a/firmware/platform/lpc43xx/include/drivers/scu.h
+++ b/firmware/platform/lpc43xx/include/drivers/scu.h
@@ -36,6 +36,23 @@ typedef enum {
 
 
 /**
+ * Enumeration specifying the drive strength to be configured for a given pin.
+ */
+typedef enum {
+	SCU_NORMAL   = 0b00,
+	SCU_MEDIUM   = 0b01,
+	SCU_HIGH     = 0b10,
+	SCU_ULTRA    = 0b11,
+
+	// Platform agnostic names.
+	DRIVE_CONFIG_NORMAL   = 0b00,
+	DRIVE_CONFIG_MEDIUM   = 0b01,
+	DRIVE_CONFIG_HIGH     = 0b10,
+	DRIVE_CONFIG_ULTRA    = 0b11,
+ } scu_drive_configuration_t;
+
+
+/**
  * Type that represents an SCU register for a given pin.
  */
 typedef struct ATTR_PACKED {
@@ -44,7 +61,8 @@ typedef struct ATTR_PACKED {
 	uint32_t use_fast_slew         : 1;
 	uint32_t input_buffer_enabled  : 1;
 	uint32_t disable_glitch_filter : 1;
-	uint32_t                       : 24;
+	uint32_t drive_strength        : 2;  
+	uint32_t                       : 22;
 } platform_scu_pin_configuration_t;
 typedef volatile platform_scu_pin_configuration_t platform_scu_pin_register_t;
 


### PR DESCRIPTION
LPC43XX microcontrollers have 10 high-drive pins:

```
P1_17
P2_3
P2_4
P2_5
P8_0
P8_1
P8_2
PA_1
PA_2
PA_3
```

This PR extends the definition of the SCU pin configuration register block by adding the drive strength register at bits `9:8`.

#### Reference: 

[UM10503 LPC43xx/LPC43Sxx ARM Cortex®-M4/M0 multi-core microcontroller User manual](https://community.nxp.com/pwmxy87654/attachments/pwmxy87654/lpc/35170/)
_Section 17.4.2 -- Pin configuration registers for high-drive pins._