### PR TITLE
Add support for configuring all gpio pin modes

### DIFF
--- a/firmware/include/drivers/gpio.h
+++ b/firmware/include/drivers/gpio.h
@@ -28,6 +28,13 @@ int gpio_configure_pinmux_and_resistors(gpio_pin_t pin, gpio_resistor_configurat
 
 
 /**
+ * Configures the system's pinmux to route the given GPIO pin to a physical pin
+ * and apply the given pin configuration.
+ */
+int gpio_configure_pinmux_and_pin(gpio_pin_t pin, gpio_pin_configuration_t pin_configuration);
+
+
+/**
  * Configures the system's pinmux to route all possible GPIO
  * pins for a given port.
  */

--- a/firmware/platform/lpc43xx/include/drivers/platform_gpio.h
+++ b/firmware/platform/lpc43xx/include/drivers/platform_gpio.h
@@ -16,6 +16,8 @@
 // For LPCxx devices, use the SCU resistor configuration as the GPIO resistor configuration.
 typedef scu_resistor_configuration_t gpio_resistor_configuration_t;
 
+// For LPCxx devices, use the SCU pin register block as the GPIO pin configuration.
+typedef platform_scu_pin_register_t gpio_pin_configuration_t;
 
 // Describe the chip's GPIO capabilities.
 #define GPIO_MAX_PORTS 6


### PR DESCRIPTION
Adds a new function to firmware gpio drivers to make it possible to enable setting of pin modes for a given GPIO:

```C
/**
 * Configures the system's pinmux to route the given GPIO pin to a physical pin
 * and apply the given pin configuration.
 */
int gpio_configure_pinmux_and_pin(gpio_pin_t pin, gpio_pin_configuration_t pin_configuration);
```

I did consider removing the - IMO now redundant -- `gpio_configure_pinmux_and_resistors()` infrastructure but there may be someone out there making use of it?

