### PR TITLE
Set DYLD_FALLBACK_LIBRARY_PATH on macOS

### DIFF
--- a/host/pygreat/board.py
+++ b/host/pygreat/board.py
@@ -7,9 +7,15 @@ Module containing the core definitions for a libgreat-driven board.
 """
 
 # FIXME: remove dependencies
-import usb
-import future
+import os
+import platform
 import time
+
+import future
+import usb
+
+if platform.system() == "Darwin":
+    os.environ["DYLD_FALLBACK_LIBRARY_PATH"] = f"{os.environ['HOMEBREW_PREFIX']}/lib/"
 
 # Use the GreatFET comms API, and the standard (core) API.
 from pygreat.comms import CommsBackend


### PR DESCRIPTION
Potential fix for https://github.com/greatscottgadgets/cynthion/issues/136

Homebrew patches it's own python so that `ctypes.find_library` can find libraries also installed by homebrew. When using a version of python not installed by Homebrew, this sets `DYLD_FALLBACK_LIBRARY_PATH` so that the homebrew-installed `libusb` library is found.

I tested this on my ARM Mac, but I don't have an Intel Mac to test this with. Can somebody with an Intel Mac try this out and see if it also works for them?