### PR TITLE
Fix incorrect field values for UART1 LCR register

### DIFF
--- a/firmware/include/drivers/uart.h
+++ b/firmware/include/drivers/uart.h
@@ -22,9 +22,9 @@ typedef enum {
 
 typedef enum {
 	NO_PARITY            = 0b000,
-	ODD_PARITY           = 0b100,
-	EVEN_PARITY          = 0b101,
-	PARITY_STUCK_AT_ONE  = 0b110,
+	ODD_PARITY           = 0b001,
+	EVEN_PARITY          = 0b011,
+	PARITY_STUCK_AT_ONE  = 0b101,
 	PARITY_STUCK_AT_ZERO = 0b111,
 } uart_parity_type_t;
 

--- a/firmware/platform/lpc43xx/include/drivers/platform_uart.h
+++ b/firmware/platform/lpc43xx/include/drivers/platform_uart.h
@@ -94,6 +94,7 @@ typedef volatile struct ATTR_PACKED {
 			uint32_t parity_mode                 : 3;
 			uint32_t use_break                   : 1;
 			uint32_t divior_latch_access_enabled : 1;
+			uint32_t                             : 24;
 		};
 		uint32_t line_control_register;
 	};


### PR DESCRIPTION
This PR fixes the values for the UART1 LCR register's parity field which were incorrectly encoded. The incorrect encoding resulted in frame errors when performing serial transmission and reception when parity was enabled.

---
Closes https://github.com/greatscottgadgets/greatfet/issues/441