### PR TITLE
Remove dependency on obsolete third-party package

### DIFF
--- a/host/pygreat/board.py
+++ b/host/pygreat/board.py
@@ -8,7 +8,6 @@ Module containing the core definitions for a libgreat-driven board.
 
 # FIXME: remove dependencies
 import usb
-import future
 import time
 
 # Use the GreatFET comms API, and the standard (core) API.

--- a/host/pygreat/comms.py
+++ b/host/pygreat/comms.py
@@ -8,10 +8,8 @@ libgreat devices.
 """
 
 from __future__ import unicode_literals
-from future import utils as future_utils
 
 import re
-import sys
 import struct
 import inspect
 import collections
@@ -776,7 +774,7 @@ class CommsBackend(object):
             # Wrap any exceptions that occur with a more specific method.
             message = "invalid arguments in call to RPC `{}`; innner message: {}; format: {}".format(name, e, in_format)
             outer_exception = type(e)(message)
-            future_utils.raise_with_traceback(outer_exception, sys.exc_info()[2])
+            raise outer_exception.with_traceback(e.__traceback__) from None
 
         # If we're not reading a response (e.g. if the output format is empty, or None),
         # truncate the max_response_length to zero. This allows backends to skip waiting for a response, when they can.
@@ -803,7 +801,7 @@ class CommsBackend(object):
             # Wrap any exceptions that occur with a more specific method.
             message = "unexpected return RPC `{}`; innner message: {}; format: {}".format(name, e, out_format)
             outer_exception = type(e)(message)
-            future_utils.raise_with_traceback(outer_exception, sys.exc_info()[2])
+            raise outer_exception.with_traceback(e.__traceback__) from None
 
         # If we have an encoding, convert any byte arguments
         # into a string.

--- a/host/pygreat/comms.py
+++ b/host/pygreat/comms.py
@@ -163,8 +163,7 @@ class CommsBackend(object):
         class_docs = self.apis['core'].get_class_docs(class_number)
 
         # Ensure that the class name is a string type that can be a class name.
-        # This ensures python2 compatibility.
-        class_name = future_utils.native_str(class_name)
+        class_name = str(class_name)
 
         # If we already have an object for the given class,
         # and we're not in overwrite mode, skip enumerating it.
@@ -1127,7 +1126,7 @@ def command_rpc(verb_number, in_format="", out_format="", name="function", class
                 timeout=timeout, max_response_length=max_response_length, encoding=encoding, *arguments)
 
     # Apply our known documentation to the given command.
-    method.__name__ = future_utils.native_str(name)
+    method.__name__ = str(name)
     method.__doc__ = doc
 
     # Generate a method signature object, so the python documentation will be correct.

--- a/host/pygreat/comms_backends/usb.py
+++ b/host/pygreat/comms_backends/usb.py
@@ -8,7 +8,6 @@ devices over USB.
 """
 
 from __future__ import absolute_import
-from future import utils as future_utils
 
 import usb
 import time
@@ -391,7 +390,7 @@ class USBCommsBackend(CommsBackend):
 
                 # If this was an error raised on the device side, covert it to a CommandFailureError.
                 if is_signaled_error and rephrase_errors:
-                    future_utils.raise_from(self._exception_for_command_failure(error_number, pretty_name), None)
+                    raise self._exception_for_command_failure(error_number, pretty_name) from None
                 else:
                     raise
         finally:

--- a/host/pygreat/comms_backends/usb1.py
+++ b/host/pygreat/comms_backends/usb1.py
@@ -8,7 +8,6 @@ devices over USB.
 """
 
 from __future__ import absolute_import
-from future import utils as future_utils
 
 import sys
 
@@ -438,7 +437,7 @@ class USB1CommsBackend(CommsBackend):
 
                 # If this was an error raised on the device side, covert it to a CommandFailureError.
                 if is_signaled_error and rephrase_errors:
-                    future_utils.raise_from(self._exception_for_command_failure(error_number, pretty_name), None)
+                    raise self._exception_for_command_failure(error_number, pretty_name) from None
                 else:
                     raise
         finally:

--- a/host/pyproject.toml
+++ b/host/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
 
 dependencies = [
     "pyusb",
-    "future",
     "backports.functools_lru_cache",
 ]
 


### PR DESCRIPTION
The third-party package [`future`](https://pypi.org/project/future/) is no longer maintained and [considered obsolete](https://github.com/PythonCharmers/python-future/blob/v1.0.0/README.rst#status) due to the end-of-life status of Python 2:

> Python 2 reached its end of life in 2020 and the python-future package should no longer be necessary. Use it to help with porting legacy code to Python 3 but don't depend on it for new code.

This PR changes all call sites to use Python 3’s native implementation and removes the `future` dependency.

## Tests

Small self-contained example to prove that the updated code works:

```py
from pygreat import comms

backend = comms.CommsBackend()
core = backend.apis['core']
core.get_available_verbs()
```

Result:

```plain
Traceback (most recent call last):
  File "/home/claudia/Documents/dev/libgreat/test.py", line 5, in <module>
    core.get_available_verbs()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/pygreat/comms.py", line 1123, in method
    return self.execute_command(verb_number, in_format, out_format, name=name, class_name=class_name,
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            timeout=timeout, max_response_length=max_response_length, encoding=encoding, *arguments)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/pygreat/comms.py", line 1278, in execute_command
    return self.comms_backend.execute_command(self.CLASS_NUMBER, verb, in_format,
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            out_format, *arguments, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/pygreat/comms.py", line 777, in execute_command
    raise outer_exception.with_traceback(e.__traceback__) from None
  File "/usr/lib/python3.13/site-packages/pygreat/comms.py", line 770, in execute_command
    payload = self.pack(in_format, *arguments)
  File "/usr/lib/python3.13/site-packages/pygreat/comms.py", line 581, in pack
    result += struct.pack(subformat, *args_consumed)
              ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
struct.error: invalid arguments in call to RPC `get_available_verbs`; innner message: pack expected 1 items for packing (got 0); format: <I
```

With syntax highlighting:

![image](https://github.com/user-attachments/assets/a17b217a-95ef-4388-b760-f21fbbe0960c)
