### PR TITLE
host: ensure the usb1 backend can check for a return error when a verb signature has no return value(s).

### DIFF
--- a/host/pygreat/comms_backends/usb1.py
+++ b/host/pygreat/comms_backends/usb1.py
@@ -480,7 +480,7 @@ class USB1CommsBackend(CommsBackend):
         USB_ERROR_NO_SUCH_DEVICE = 19
 
         try:
-            self.device_handle.clearHalt()
+            self.device_handle.clearHalt(0)
             return True
         except usb1.USBErrorNotFound:
             return True


### PR DESCRIPTION
There was a small bug in the `execute_raw_command` implementation on the `usb1` backend that would prevent an error return from being checked for verbs with no return value(s).